### PR TITLE
Enable pay button with 0 balance

### DIFF
--- a/src-ui/views/Dashboard.svelte
+++ b/src-ui/views/Dashboard.svelte
@@ -143,6 +143,6 @@
 
     <Footer>
         <Button disabled={!$account} onClick={() => goto('request')} label="Request" double />
-        <Button disabled={!$balance} onClick={() => goto('pay')} label="Pay" double />
+        <Button onClick={() => goto('pay')} label="Pay" double />
     </Footer>
 </main>


### PR DESCRIPTION
No need to disable pay button without a balance. Perhaps more frustrating UX to do so.