### PR TITLE
Prevent form submit on denomination dropdown button clicks

### DIFF
--- a/src-ui/components/inputs/Amount.svelte
+++ b/src-ui/components/inputs/Amount.svelte
@@ -113,6 +113,7 @@
     {/if}
     <button
         on:click={(e) => {
+            e.preventDefault()
             e.stopPropagation()
             dropdown = !dropdown
         }}>
@@ -122,7 +123,8 @@
         {#each units as item}
             <button
                 class:active={unit === item}
-                on:click={() => {
+                on:click={(e) => {
+                    e.preventDefault()
                     unit = item
                 }}>
                 {item}


### PR DESCRIPTION
Denomination dropdown buttons triggered parent form submission leading to application reload.

Fixes #45 