### PR TITLE
Do not attempt to destroy scanner object if it has already been destroyed

### DIFF
--- a/src-ui/views/Pay.svelte
+++ b/src-ui/views/Pay.svelte
@@ -124,8 +124,6 @@
                     const result = parseLink(data)
                     if (result) {
                         setCDA(result)
-                        scanner.destroy()
-                        scanner = null
                     }
                 })
                 scanner.start()


### PR DESCRIPTION
Fixes #64

`scanner` object is already destroyed [here](https://github.com/iotaledger/spark-wallet/blob/master/src-ui/views/Pay.svelte#L109-L112), so no need to make an attempt to do the clean up again.