### PR TITLE
Fix attachToTangle event listener

### DIFF
--- a/src-ui/lib/account.ts
+++ b/src-ui/lib/account.ts
@@ -57,8 +57,6 @@ export const updateHistory = async (
     
     const bundle = !(payload instanceof Array) ? payload.bundle : payload
 
-    console.log(incoming, bundle)
-
     const tx =
         incoming && !(payload instanceof Array)
             ? bundle.find((item) => item.value > 0 && item.address === payload.address)


### PR DESCRIPTION
Account module `attachToTangle` event response is a bundle array; not in the same form as for other events – an object holding the bundle array and corresponding CDA address