### PR TITLE
Add production aliases

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,6 +1,7 @@
 {
     "version": 2,
     "name": "spark-wallet",
+    "alias": ["spark.iota.org", "spark-devnet.iota.org"],
     "builds": [
         {
             "src": "api/**/*.ts",


### PR DESCRIPTION
Add `spark.iota.org` and `spark-devnet.iota.org` deployment aliases.