### PR TITLE
Fix camera mirrored on mobile devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "kdbxweb": "^1.5.7",
         "lottie-web": "^5.5.10",
         "ntpclient": "^1.0.2",
-        "qr-scanner": "^1.1.1",
+        "qr-scanner": "rihardsgravis/qr-scanner",
         "qrcode": "^1.4.4",
         "svelte": "^3.16.5",
         "url-parse": "^1.4.7"

--- a/src-ui/views/Pay.svelte
+++ b/src-ui/views/Pay.svelte
@@ -243,11 +243,17 @@
         }
     }
 
-    video {
+    .video-container {
         position: absolute;
-        top: 50%;
+        top: 0px;
         left: 50%;
-        transform: translate(-50%, -50%) scaleX(-1) !important;
+        height: 100%;
+        width: auto;
+        transform: translate(-50%, 0);
+    }
+
+    video {
+        display: block;
         height: 100%;
     }
 
@@ -328,9 +334,11 @@
                 <Footer>
                     <Button disabled={paymentLink.length === 0} onClick={onPaymentLink} label="Send" />
                 </Footer>
-            {:else}
+                {:else}
                 <scanner class:enabled={scanner}>
-                    <video bind:this={video} autoplay playsinline />
+                    <div class="video-container">
+                        <video bind:this={video} autoplay playsinline />
+                    </div>
                     <svg width="204" height="204" xmlns="http://www.w3.org/2000/svg">
                         <path
                             d="M167 10V0h26.976c5.523 0 10 4.477 10 10v27h-10V10H167zM36.976 10H10v27H0V10C0 4.477 4.477 0 10

--- a/yarn.lock
+++ b/yarn.lock
@@ -6534,10 +6534,9 @@ q@^1.1.2:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qr-scanner@^1.1.1:
+qr-scanner@rihardsgravis/qr-scanner:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/qr-scanner/-/qr-scanner-1.1.1.tgz#49775d3992733b5198f01a9aa65225962b0cb17d"
-  integrity sha512-vZmtaIpxx4rqnrg4iX62pQJ12bcIpfTEe/hL4Pr5PwQ/fih8W+ErfAZVFnnrdipeDC6L+5BfzMIqs/s6SYi4WA==
+  resolved "https://codeload.github.com/rihardsgravis/qr-scanner/tar.gz/75d0b127fc1acbea4b0c4f3dafc8c47ffa6e0dfc"
 
 qrcode@^1.4.4:
   version "1.4.4"


### PR DESCRIPTION
- Fork and update `qr-scanner` with PR's fixing [desktop Safari](https://github.com/nimiq/qr-scanner/pull/42) and [Firefox](https://github.com/nimiq/qr-scanner/pull/41) bugs
- Remove !important video transform override to make mirroring optional

Fixes #82 