### PR TITLE
Update @iota/account package to 1.0.0-beta.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "dependencies": {
         "@capacitor/core": "^1.4.0",
         "@capacitor/ios": "^1.4.0",
-        "@iota/account": "1.0.0-beta.27",
+        "@iota/account": "1.0.0-beta.28",
         "@iota/cda": "^1.0.0-beta.23",
         "@iota/converter": "^1.0.0-beta.23",
         "@iota/persistence": "^1.0.0-beta.23",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "dependencies": {
         "@capacitor/core": "^1.4.0",
         "@capacitor/ios": "^1.4.0",
-        "@iota/account": "^1.0.0-beta.25",
+        "@iota/account": "1.0.0-beta.27",
         "@iota/cda": "^1.0.0-beta.23",
         "@iota/converter": "^1.0.0-beta.23",
         "@iota/persistence": "^1.0.0-beta.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,10 +77,10 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
-"@iota/account@1.0.0-beta.27":
-  version "1.0.0-beta.27"
-  resolved "https://registry.yarnpkg.com/@iota/account/-/account-1.0.0-beta.27.tgz#40b2ab97038c898acb2fb2efff19c108133c7efc"
-  integrity sha512-UMMyiRwIFeeQvXj8MlDuR986MfZ4MoNApNUGKh6UYKVVprYd2zxxkq/hfM1ikIZ8omf4SaFq9SZuD1haMFgAdw==
+"@iota/account@1.0.0-beta.28":
+  version "1.0.0-beta.28"
+  resolved "https://registry.yarnpkg.com/@iota/account/-/account-1.0.0-beta.28.tgz#b420f2da8835edf06df501de1c10b621f46bd8c2"
+  integrity sha512-bDKZb0Rnv5BYzGNi5XrGAK7YoBt5nmlLhnqMVUfHPhwzaYhAEw8TPCX1Y/0WvkeB8y7D5bXKbCbEquUfWtIKCw==
   dependencies:
     "@iota/async-buffer" "^1.0.0-beta.23"
     "@iota/bundle" "^1.0.0-beta.23"

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,16 +77,16 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
-"@iota/account@^1.0.0-beta.25":
-  version "1.0.0-beta.25"
-  resolved "https://registry.yarnpkg.com/@iota/account/-/account-1.0.0-beta.25.tgz#1f9534c0c558576c52a128c96b053448a385e7d9"
-  integrity sha512-DNVx3ILomb9Pr8GFo9awXS25I81Z8SDG+fBcViZmh9hfxn6cOryRBUW+l4X7hv/5ZrBT2dr8mOmhvhIfvr4REg==
+"@iota/account@1.0.0-beta.27":
+  version "1.0.0-beta.27"
+  resolved "https://registry.yarnpkg.com/@iota/account/-/account-1.0.0-beta.27.tgz#40b2ab97038c898acb2fb2efff19c108133c7efc"
+  integrity sha512-UMMyiRwIFeeQvXj8MlDuR986MfZ4MoNApNUGKh6UYKVVprYd2zxxkq/hfM1ikIZ8omf4SaFq9SZuD1haMFgAdw==
   dependencies:
     "@iota/async-buffer" "^1.0.0-beta.23"
     "@iota/bundle" "^1.0.0-beta.23"
     "@iota/cda" "^1.0.0-beta.23"
     "@iota/converter" "^1.0.0-beta.23"
-    "@iota/core" "^1.0.0-beta.24"
+    "@iota/core" "^1.0.0-beta.27"
     "@iota/curl" "^1.0.0-beta.19"
     "@iota/http-client" "^1.0.0-beta.23"
     "@iota/persistence" "^1.0.0-beta.23"
@@ -151,10 +151,10 @@
   dependencies:
     core-js "^3.1.4"
 
-"@iota/core@^1.0.0-beta.24":
-  version "1.0.0-beta.24"
-  resolved "https://registry.yarnpkg.com/@iota/core/-/core-1.0.0-beta.24.tgz#1304f97682e357d7301888de68302cc775418b45"
-  integrity sha512-WPRA2VJN4cgp03aglM+IXRq3plIYvPd/Uxbw5tp8uLnsJPGzwVeKRNn7g4h1Pz9Jc6u09/Aymke+C4BORO7Wfg==
+"@iota/core@^1.0.0-beta.27":
+  version "1.0.0-beta.27"
+  resolved "https://registry.yarnpkg.com/@iota/core/-/core-1.0.0-beta.27.tgz#d2e7aaca6713b357b22f0d6fbb5cdbd93059a732"
+  integrity sha512-LprJRSW3kIITlGkhJlItQLlimlgvIUo3NuUDJgzRZ1eAEhL0JVckjiOCWkQd/MX7ngsBsDhY81Zevhp/JT1qsg==
   dependencies:
     "@iota/bundle" "^1.0.0-beta.23"
     "@iota/bundle-validator" "^1.0.0-beta.23"


### PR DESCRIPTION
Update `@iota/account` to `1.0.0-beta.27` with the following changes:
1. Generate unspent addresses that have no transactions. ~Don't persist used addresses~. (https://github.com/iotaledger/iota.js/pull/446)
2. Attach new addresses until confirmed. (https://github.com/iotaledger/iota.js/pull/447)
3. Ignore ~and drop~ spent inputs. (https://github.com/iotaledger/iota.js/pull/448)
4. Keep track of used addresses to show their history and allow spending from unspent ones only.(https://github.com/iotaledger/iota.js/pull/452)