### PR TITLE
fix: Bump file-saver to eligrey/FileSaver.js@648ff96

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "capacitor-camera-preview": "^0.2.0",
         "chartist": "^0.11.4",
         "currency-codes": "^1.5.1",
-        "file-saver": "^2.0.2",
+        "file-saver": "https://github.com/eligrey/FileSaver.js#648ff96f8b2b69024c719e018ec20712771b8470",
         "hammerjs": "^2.0.8",
         "kdbxweb": "^1.5.7",
         "lottie-web": "^5.5.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3180,6 +3180,10 @@ file-saver@^2.0.2:
   resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.2.tgz#06d6e728a9ea2df2cce2f8d9e84dfcdc338ec17a"
   integrity sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw==
 
+"file-saver@https://github.com/eligrey/FileSaver.js#648ff96f8b2b69024c719e018ec20712771b8470":
+  version "2.0.3"
+  resolved "https://github.com/eligrey/FileSaver.js#648ff96f8b2b69024c719e018ec20712771b8470"
+
 file-type@5.2.0, file-type@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-5.2.0.tgz#2ddbea7c73ffe36368dfae49dc338c058c2b8ad6"


### PR DESCRIPTION
Includes eligrey/FileSaver.js#613, which fixes an issue on macOS when exporting SeedVaults

Fixes #89 